### PR TITLE
added test helper

### DIFF
--- a/interpolate.go
+++ b/interpolate.go
@@ -43,6 +43,20 @@ func InterpolateForDialect(query string, value []interface{}, d Dialect) (string
 	return i.String(), nil
 }
 
+// InterpolateForDialectFromBuilder is used to render the query string that is produced by a
+// Builder. This is only intended to be used for testing purposes.
+func InterpolateForDialectFromBuilder(builder Builder, d Dialect) (string, error) {
+	i := interpolator{
+		Buffer:  NewBuffer(),
+		Dialect: d,
+	}
+	err := i.encodePlaceholder(builder, true)
+	if err != nil {
+		return "", err
+	}
+	return i.String(), nil
+}
+
 var escapedPlaceholder = strings.Repeat(placeholder, 2)
 
 func (i *interpolator) interpolate(query string, value []interface{}, topLevel bool) error {


### PR DESCRIPTION
We are trying to generate SQL query strings for golden tests. We used `InterpolateForDialect` as this was the recommended public function. However, we found that `InterpolateForDialect` has weird edge cases where it doesn't work. However, the DBR library uses a separate code path to render the query before sending it to the database. After tracing the code path, I found that if uses an `interpolator` with the `encodePlaceholder` method, both private. The idea here is to expose a function that is used only for testing purposes.